### PR TITLE
Test that restarted nodes are reset before continuing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+YAML_FILES=$(shell find . -iname '*.yml')
+JSON_FILES=$(patsubst %.yml,%.json,$(YAML_FILES))
+
+all: $(JSON_FILES)
+
+%.json : %.yml
+	jwc yaml2json $< > $@

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,30 @@ Mongo Orchestration cluster integration tests
 The YAML and JSON files in this directory tree are platform-independent 
 integration tests that drivers can use with the Mongo Orchestration service.
 
+Converting to JSON
+------------------
+
+The tests are written in YAML because it is easier for humans to write and read,
+and because YAML includes a standard comment format. A JSONified version of each
+YAML file is included in this repository. Whenever you change the YAML,
+re-convert to JSON. One method to convert to JSON is with
+`jsonwidget-python <http://jsonwidget.org/wiki/Jsonwidget-python>`_::
+
+    pip install PyYAML urwid jsonwidget    make
+    make
+
+Or instead of "make"::
+
+    for i in `find . -iname '*.yml'`; do
+        echo "${i%.*}"
+        jwc yaml2json $i > ${i%.*}.json
+    done
+
+Alternatively, you can use `yamljs <https://www.npmjs.com/package/yamljs>`_::
+
+    npm install -g yamljs
+    yaml2json -s -p -r .
+
 Format
 ------
 

--- a/rs/connection/read/primary-available.json
+++ b/rs/connection/read/primary-available.json
@@ -1,0 +1,58 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {}
+    }, 
+    "description": "Successful read from an available primary", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/connection/read/primary-not-available.json
+++ b/rs/connection/read/primary-not-available.json
@@ -1,0 +1,64 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {}
+    }, 
+    "description": "Read failure when primary is not available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "DELETE", 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/connection/read/primary-restarted.json
+++ b/rs/connection/read/primary-restarted.json
@@ -1,0 +1,84 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {}
+    }, 
+    "description": "Successful read from a restarted primary", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "restart"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/connection/read/primary-restarted.yml
+++ b/rs/connection/read/primary-restarted.yml
@@ -52,6 +52,13 @@ phases: [
                            uri: "/servers/serverA",
                            payload: { action: "restart" }
                          }
+          },
+
+          {
+            MOOperation: { method: "POST",
+                           uri: "/servers/serverA",
+                           payload: { action: "reset" }
+                         }
           }
         ]
 

--- a/rs/connection/write/primary-available.json
+++ b/rs/connection/write/primary-available.json
@@ -1,0 +1,49 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {}
+    }, 
+    "description": "Successful write to an available primary", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [], 
+    "tests": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/connection/write/primary-not-available.json
+++ b/rs/connection/write/primary-not-available.json
@@ -1,0 +1,59 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {}
+    }, 
+    "description": "Write failure when primary is not available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/connection/write/primary-restarted.json
+++ b/rs/connection/write/primary-restarted.json
@@ -1,0 +1,79 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {}
+    }, 
+    "description": "Successful write to a restarted primary", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "restart"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 2
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/connection/write/primary-restarted.yml
+++ b/rs/connection/write/primary-restarted.yml
@@ -44,6 +44,13 @@ phases: [
                            uri: "/servers/serverA",
                            payload: { action: "restart" }
                          }
+          },
+
+          {
+            MOOperation: { method: "POST",
+                           uri: "/servers/serverA",
+                           payload: { action: "reset" }
+                         }
           }
         ]
 

--- a/rs/discovery/new-primary-detected.json
+++ b/rs/discovery/new-primary-detected.json
@@ -1,0 +1,80 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "heartbeatFrequency": 2, 
+            "readPreference": {
+                "mode": "primary"
+            }
+        }
+    }, 
+    "description": "Client detects primary failure and newly elected members", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 2
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "wait": 3
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientHosts": {
+                "primary": "serverB", 
+                "secondaries": [
+                    "serverC"
+                ]
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/discovery/new-secondary-detected.json
+++ b/rs/discovery/new-secondary-detected.json
@@ -1,0 +1,77 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "heartbeatFrequency": 2, 
+            "readPreference": {
+                "mode": "secondary"
+            }
+        }
+    }, 
+    "description": "Client detects secondary failure and newly elected members", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 2
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverB"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientHosts": {
+                "primary": "serverA", 
+                "secondaries": [
+                    "serverC"
+                ]
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/discovery/primary-stepdown.json
+++ b/rs/discovery/primary-stepdown.json
@@ -1,0 +1,75 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "heartbeatFrequency": 2
+        }
+    }, 
+    "description": "Client detects primary stepdown", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 2
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stepdown"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "wait": 2
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 2
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/discovery/recovering-member-triggers-refresh.json
+++ b/rs/discovery/recovering-member-triggers-refresh.json
@@ -1,0 +1,66 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "heartbeatFrequency": 1, 
+            "readPreference": {
+                "mode": "secondary"
+            }
+        }
+    }, 
+    "description": "A recovering member triggers a refresh", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "server_id": "serverA"
+            }, 
+            {
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "restart"
+                }, 
+                "uri": "/servers/serverB"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "wait": 1
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/discovery/recovering-member-triggers-refresh.yml
+++ b/rs/discovery/recovering-member-triggers-refresh.yml
@@ -48,6 +48,13 @@ phases: [
           },
 
           {
+            MOOperation: { method: "POST",
+                           uri: "/servers/serverB",
+                           payload: { action: "reset" }
+                          }
+          },
+
+          {
             clientOperation: { operation: "find",
                                outcome: { ok: 0 }
                              }

--- a/rs/discovery/remove-all-add-members.json
+++ b/rs/discovery/remove-all-add-members.json
@@ -1,0 +1,84 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB"
+        ], 
+        "options": {
+            "heartbeatFrequency": 1
+        }
+    }, 
+    "description": "Client detects changes in replica set", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "server_id": "serverA"
+            }, 
+            {
+                "server_id": "serverB"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "rsParams": {
+                        "priority": 1
+                    }, 
+                    "server_id": "serverC"
+                }, 
+                "uri": "/replica_sets/integration_tests/members"
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "rsParams": {
+                        "priority": 0
+                    }, 
+                    "server_id": "serverD"
+                }, 
+                "uri": "/replica_sets/integration_tests/members"
+            }
+        }, 
+        {
+            "wait": 1
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverB"
+            }
+        }, 
+        {
+            "wait": 1
+        }
+    ], 
+    "tests": [
+        {
+            "clientHosts": {
+                "primary": "serverC", 
+                "secondaries": [
+                    "serverD"
+                ]
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/discovery/remove-members-add-primary.json
+++ b/rs/discovery/remove-members-add-primary.json
@@ -1,0 +1,87 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "heartbeatFrequency": 1
+        }
+    }, 
+    "description": "Client detects new primary", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "rsParams": {
+                        "priority": 1
+                    }, 
+                    "server_id": "serverD"
+                }, 
+                "uri": "/replica_sets/integration_tests/members"
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "rsParams": {
+                        "priority": 0
+                    }, 
+                    "server_id": "serverE"
+                }, 
+                "uri": "/replica_sets/integration_tests/members"
+            }
+        }, 
+        {
+            "wait": 1
+        }
+    ], 
+    "tests": [
+        {
+            "clientHosts": {
+                "primary": "serverD", 
+                "secondaries": [
+                    "serverB", 
+                    "serverC", 
+                    "serverE"
+                ]
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/discovery/server-discovery-using-arbiter.json
+++ b/rs/discovery/server-discovery-using-arbiter.json
@@ -1,0 +1,50 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverC"
+        ], 
+        "options": {
+            "heartbeatFrequency": 1
+        }
+    }, 
+    "description": "Client uses arbiter to discover all members", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "wait": 1
+        }
+    ], 
+    "tests": [
+        {
+            "clientHosts": {
+                "primary": "serverA", 
+                "secondaries": [
+                    "serverB"
+                ]
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/discovery/stepped-down-primary-triggers-refresh.json
+++ b/rs/discovery/stepped-down-primary-triggers-refresh.json
@@ -1,0 +1,75 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "heartbeatFrequency": 1, 
+            "readPreference": {
+                "mode": "primary"
+            }
+        }
+    }, 
+    "description": "A stepped-down primary triggers a refresh", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 2
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stepdown"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "wait": 1
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/read-preference/primary/all-servers.json
+++ b/rs/read-preference/primary/all-servers.json
@@ -1,0 +1,62 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "readPreference": {
+                "mode": "primary"
+            }
+        }
+    }, 
+    "description": "Successful read with primary read preference and all servers available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "writeConcern": {
+                    "w": 3
+                }
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/read-preference/primary/primary-not-available.json
+++ b/rs/read-preference/primary/primary-not-available.json
@@ -1,0 +1,71 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "readPreference": {
+                "mode": "primary"
+            }
+        }
+    }, 
+    "description": "Read failure with primary read preference and primary is not available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "writeConcern": {
+                    "w": 3
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/read-preference/primary/primary-restarted.json
+++ b/rs/read-preference/primary/primary-restarted.json
@@ -1,0 +1,91 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "readPreference": {
+                "mode": "primary"
+            }
+        }
+    }, 
+    "description": "Successful read with primary read preference from restarted primary", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "writeConcern": {
+                    "w": 3
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "restart"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "wait": 3
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/read-preference/primary/primary-restarted.yml
+++ b/rs/read-preference/primary/primary-restarted.yml
@@ -55,6 +55,13 @@ phases: [
           },
 
           {
+            MOOperation: { method: "POST",
+                           uri: "/servers/serverA",
+                           payload: { action: "reset" }
+                         }
+          },
+
+          {
             wait: 3
           }
         ]

--- a/rs/read-preference/primary/primary-restarted.yml
+++ b/rs/read-preference/primary/primary-restarted.yml
@@ -52,7 +52,7 @@ phases: [
                            uri: "/servers/serverA",
                            payload: { action: "restart" }
                          }
-          }
+          },
 
           {
             wait: 3

--- a/rs/read-preference/secondary/all-servers.json
+++ b/rs/read-preference/secondary/all-servers.json
@@ -1,0 +1,62 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "readPreference": {
+                "mode": "secondary"
+            }
+        }
+    }, 
+    "description": "Successful read with secondary read preference and all servers available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "writeConcern": {
+                    "w": 3
+                }
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/read-preference/secondary/secondary-not-available.json
+++ b/rs/read-preference/secondary/secondary-not-available.json
@@ -1,0 +1,71 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "readPreference": {
+                "mode": "secondary"
+            }
+        }
+    }, 
+    "description": "Read failure with secondary read preference and secondary is not available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "writeConcern": {
+                    "w": 3
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverB"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/read-preference/secondary/secondary-restarted.json
+++ b/rs/read-preference/secondary/secondary-restarted.json
@@ -1,0 +1,88 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA", 
+            "serverB", 
+            "serverC"
+        ], 
+        "options": {
+            "readPreference": {
+                "mode": "secondary"
+            }
+        }
+    }, 
+    "description": "Successful read with secondary read preference from restarted secondary", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "members": [
+            {
+                "rsParams": {
+                    "priority": 1
+                }, 
+                "server_id": "serverA"
+            }, 
+            {
+                "rsParams": {
+                    "priority": 0
+                }, 
+                "server_id": "serverB"
+            }, 
+            {
+                "rsParams": {
+                    "arbiterOnly": true
+                }, 
+                "server_id": "serverC"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "writeConcern": {
+                    "w": 3
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverB"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "restart"
+                }, 
+                "uri": "/servers/serverB"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "replica_sets"
+}

--- a/rs/read-preference/secondary/secondary-restarted.yml
+++ b/rs/read-preference/secondary/secondary-restarted.yml
@@ -52,6 +52,13 @@ phases: [
                            uri: "/servers/serverB",
                            payload: { action: "restart" }
                          }
+          },
+
+          {
+            MOOperation: { method: "POST",
+                           uri: "/servers/serverB",
+                           payload: { action: "reset" }
+                         }
           }
         ]
 

--- a/sharded/connection/all-mongos-available.json
+++ b/sharded/connection/all-mongos-available.json
@@ -1,0 +1,38 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "mongosA", 
+            "mongosB"
+        ], 
+        "options": {}
+    }, 
+    "description": "Successful read with all mongos' available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "routers": [
+            {
+                "server_id": "mongosA"
+            }, 
+            {
+                "server_id": "mongosB"
+            }
+        ], 
+        "shards": [
+            {
+                "id": "sh1"
+            }
+        ]
+    }, 
+    "phases": [], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "sharded_clusters"
+}

--- a/sharded/connection/all-mongos-available.yml
+++ b/sharded/connection/all-mongos-available.yml
@@ -11,7 +11,7 @@ initConfig: { id: "integration_tests",
               routers: [
                          { server_id: "mongosA" },
                          { server_id: "mongosB" }
-                       ]
+                       ],
               shards: [
                         { id: "sh1" }
                       ]

--- a/sharded/connection/mongos-restarted.json
+++ b/sharded/connection/mongos-restarted.json
@@ -1,0 +1,67 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "mongosA", 
+            "mongosB"
+        ], 
+        "options": {
+            "heartbeatFrequency": 1
+        }
+    }, 
+    "description": "Successful read from restarted mongos", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "routers": [
+            {
+                "server_id": "mongosA"
+            }, 
+            {
+                "server_id": "mongosB"
+            }
+        ], 
+        "shards": [
+            {
+                "id": "sh1"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/mongosA"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "restart"
+                }, 
+                "uri": "/servers/mongosA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "sharded_clusters"
+}

--- a/sharded/connection/mongos-restarted.yml
+++ b/sharded/connection/mongos-restarted.yml
@@ -45,6 +45,13 @@ phases: [
                            uri: "/servers/mongosA",
                            payload: { action: "restart" }
                          }
+          },
+
+          {
+            MOOperation: { method: "POST",
+                           uri: "/servers/mongosA",
+                           payload: { action: "reset" }
+                         }
           }
         ]
 

--- a/sharded/connection/mongos-restarted.yml
+++ b/sharded/connection/mongos-restarted.yml
@@ -12,7 +12,7 @@ initConfig: { id: "integration_tests",
               routers: [
                          { server_id: "mongosA" },
                          { server_id: "mongosB" }
-                       ]
+                       ],
               shards: [
                         { id: "sh1" }
                       ]

--- a/sharded/connection/no-mongos-available.json
+++ b/sharded/connection/no-mongos-available.json
@@ -1,0 +1,70 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "mongosA", 
+            "mongosB"
+        ], 
+        "options": {
+            "heartbeatFrequency": 1
+        }
+    }, 
+    "description": "Read failure when neither mongos' are available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "routers": [
+            {
+                "server_id": "mongosA"
+            }, 
+            {
+                "server_id": "mongosB"
+            }
+        ], 
+        "shards": [
+            {
+                "id": "sh1"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/mongosA"
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/mongosB"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }
+    ], 
+    "type": "sharded_clusters"
+}

--- a/sharded/connection/no-mongos-available.yml
+++ b/sharded/connection/no-mongos-available.yml
@@ -10,7 +10,7 @@ initConfig: { id: "integration_tests",
               routers: [
                          { server_id: "mongosA" },
                          { server_id: "mongosB" }
-                       ]
+                       ],
               shards: [
                         { id: "sh1" }
                       ]

--- a/sharded/connection/one-mongos-not-available.json
+++ b/sharded/connection/one-mongos-not-available.json
@@ -1,0 +1,61 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "mongosA", 
+            "mongosB"
+        ], 
+        "options": {
+            "heartbeatFrequency": 1
+        }
+    }, 
+    "description": "Successful read with one mongos not available", 
+    "initConfig": {
+        "id": "integration_tests", 
+        "routers": [
+            {
+                "server_id": "mongosA"
+            }, 
+            {
+                "server_id": "mongosB"
+            }
+        ], 
+        "shards": [
+            {
+                "id": "sh1"
+            }
+        ]
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/mongosA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "sharded_clusters"
+}

--- a/sharded/connection/one-mongos-not-available.yml
+++ b/sharded/connection/one-mongos-not-available.yml
@@ -10,7 +10,7 @@ initConfig: { id: "integration_tests",
               routers: [
                          { server_id: "mongosA" },
                          { server_id: "mongosB" }
-                       ]
+                       ],
               shards: [
                         { id: "sh1" }
                       ]

--- a/single/connection/read/standalone-available.json
+++ b/single/connection/read/standalone-available.json
@@ -1,0 +1,35 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA"
+        ]
+    }, 
+    "description": "Successful read from standalone", 
+    "initConfig": {
+        "id": "serverA"
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "servers"
+}

--- a/single/connection/read/standalone-not-available.json
+++ b/single/connection/read/standalone-not-available.json
@@ -1,0 +1,44 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA"
+        ]
+    }, 
+    "description": "Read failure when standlone is not available", 
+    "initConfig": {
+        "id": "serverA"
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }
+    ], 
+    "type": "servers"
+}

--- a/single/connection/read/standalone-restarted.json
+++ b/single/connection/read/standalone-restarted.json
@@ -1,0 +1,61 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA"
+        ]
+    }, 
+    "description": "Successful read from restarted standalone", 
+    "initConfig": {
+        "id": "serverA"
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "restart"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "operation": "find", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "servers"
+}

--- a/single/connection/read/standalone-restarted.yml
+++ b/single/connection/read/standalone-restarted.yml
@@ -19,7 +19,7 @@ clientSetUp: {
 phases: [
           {
             clientOperation: { operation: "insertOne",
-                               doc: { x: 1 }
+                               doc: { x: 1 },
                                outcome: { ok: 1 }
                              }
           },

--- a/single/connection/read/standalone-restarted.yml
+++ b/single/connection/read/standalone-restarted.yml
@@ -42,6 +42,13 @@ phases: [
                            uri: "/servers/serverA",
                            payload: { action: "restart" }
                          }
+          },
+
+          {
+            MOOperation: { method: "POST",
+                           uri: "/servers/serverA",
+                           payload: { action: "reset" }
+                         }
           }
         ]
 

--- a/single/connection/write/standalone-available.json
+++ b/single/connection/write/standalone-available.json
@@ -1,0 +1,26 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA"
+        ]
+    }, 
+    "description": "Successful write to a standalone", 
+    "initConfig": {
+        "id": "serverA"
+    }, 
+    "phases": [], 
+    "tests": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "servers"
+}

--- a/single/connection/write/standalone-not-available.json
+++ b/single/connection/write/standalone-not-available.json
@@ -1,0 +1,36 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA"
+        ]
+    }, 
+    "description": "Write failure when standlone is not available", 
+    "initConfig": {
+        "id": "serverA"
+    }, 
+    "phases": [
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }
+    ], 
+    "type": "servers"
+}

--- a/single/connection/write/standalone-restarted.json
+++ b/single/connection/write/standalone-restarted.json
@@ -1,0 +1,67 @@
+{
+    "clientSetUp": {
+        "hosts": [
+            "serverA"
+        ]
+    }, 
+    "description": "Successful write to a restarted standalone", 
+    "initConfig": {
+        "id": "serverA"
+    }, 
+    "phases": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 1
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "stop"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }, 
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 2
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 0
+                }
+            }
+        }, 
+        {
+            "MOOperation": {
+                "method": "POST", 
+                "payload": {
+                    "action": "restart"
+                }, 
+                "uri": "/servers/serverA"
+            }
+        }
+    ], 
+    "tests": [
+        {
+            "clientOperation": {
+                "doc": {
+                    "x": 3
+                }, 
+                "operation": "insertOne", 
+                "outcome": {
+                    "ok": 1
+                }
+            }
+        }
+    ], 
+    "type": "servers"
+}

--- a/single/connection/write/standalone-restarted.yml
+++ b/single/connection/write/standalone-restarted.yml
@@ -43,6 +43,13 @@ phases: [
                            uri: "/servers/serverA",
                            payload: { action: "restart" }
                          }
+          },
+
+          {
+            MOOperation: { method: "POST",
+                           uri: "/servers/serverA",
+                           payload: { action: "reset" }
+                         }
           }
         ]
 


### PR DESCRIPTION
This incorporates commits from #5 and #6, as I needed them to convert the JSON for the last commit.

MO has a "reset" endpoint that (a) starts the server if it isn't already up and (b) waits for it to respond to an isMaster command. It seemed like this might be necessary for single-threaded drivers that only invoke server selection once (instead of polling over an interval), but we can discuss before merging.
